### PR TITLE
Create interval only if mouse is not pressed

### DIFF
--- a/src/timer/Timer.js
+++ b/src/timer/Timer.js
@@ -8,14 +8,14 @@ function Timer () {
 
   // Timer
   useEffect(function () {
-    const timerId = setInterval(function () {
-      if (!mousePressed) {
+    if (!mousePressed) {
+      const timerId = setInterval(function () {
         setMilliseconds(m => m + 1)
-      }
-    }, 1)
+      }, 1)
 
-    return function cleanup () {
-      clearInterval(timerId)
+      return function cleanup () {
+        clearInterval(timerId)
+      }
     }
   }, [mousePressed])
 


### PR DESCRIPTION
Having the if conditional inside the interval function means you are creating a new interval when the mouse is pressed which then checks whether or not the mouse is pressed every millisecond even though we already know it's pressed.

I know it's probably unnecessary optimization but I suggest moving the conditional outside of the interval function so you are only creating an interval when we want to.